### PR TITLE
Add GitHub Actions workflows for CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Build Docker image
+      run: docker build --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --tag cbftp:latest .
+
+    - name: Save Docker cache
+      if: success()
+      run: mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ${{ secrets.DOCKER_USERNAME }}/cbftp:latest
+
+    - name: Deploy to server
+      run: |
+        ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'EOF'
+          docker pull ${{ secrets.DOCKER_USERNAME }}/cbftp:latest
+          docker stop cbftp || true
+          docker rm cbftp || true
+          docker run -d --name cbftp -p 55477:55477 ${{ secrets.DOCKER_USERNAME }}/cbftp:latest
+        EOF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run tests
+      run: |
+        python -m unittest discover

--- a/README.md
+++ b/README.md
@@ -97,3 +97,21 @@ This fork maintains the original CBFTP license.
 ## Original CBFTP Repository
 
 The original CBFTP can be found at: https://github.com/cbftp/cbftp 
+
+## GitHub Actions Workflows and CI/CD Pipeline
+
+This project uses GitHub Actions for continuous integration and deployment. The following workflows are included:
+
+### Build Workflow
+The build workflow is responsible for compiling the project. It is triggered on every push and pull request to the `main` branch.
+
+### Test Workflow
+The test workflow runs the project's test suite. It is triggered on every push and pull request to the `main` branch.
+
+### Deploy Workflow
+The deploy workflow handles the deployment of the project. It is triggered on every push to the `main` branch and on the creation of new tags.
+
+### Using the Workflows
+To use the GitHub Actions workflows, simply push your changes to the repository. The workflows will be triggered automatically based on the specified events.
+
+For more details on the workflows, refer to the `.github/workflows` directory in the repository.


### PR DESCRIPTION
Add GitHub Actions workflows for build, test, and deploy.

* **README.md**
  - Add a section about GitHub Actions workflows and CI/CD pipeline.
  - Mention the new GitHub Actions workflows and their purpose.
  - Provide instructions on how to use the workflows.

* **.github/workflows/build.yml**
  - Create a GitHub Actions workflow for building the project.
  - Define jobs for setting up the environment and running the build.
  - Specify triggers for the workflow.

* **.github/workflows/test.yml**
  - Create a GitHub Actions workflow for running tests.
  - Define jobs for setting up the environment and running tests.
  - Specify triggers for the workflow.

* **.github/workflows/deploy.yml**
  - Create a GitHub Actions workflow for deploying the project.
  - Define jobs for setting up the environment and deploying the project.
  - Specify triggers for the workflow.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ZarTek-Creole/cbftp-timejobsection/pull/1?shareId=47a7ee8d-8cca-460b-b72b-86f654275e95).